### PR TITLE
Semaphoreを使ってキュー構造を実装する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,23 @@
 *.exe
 *.out
 *.app
+
+## Build generated
+build/
+DerivedData/
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+
+## Other
+*.moved-aside
+*.xccheckout
+*.xcscmblueprint

--- a/MultiThread/MultiThread.xcodeproj/project.pbxproj
+++ b/MultiThread/MultiThread.xcodeproj/project.pbxproj
@@ -1,0 +1,255 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		3020B53B1F26E681000A2332 /* main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3020B53A1F26E681000A2332 /* main.cpp */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		3020B5351F26E681000A2332 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		3020B5371F26E681000A2332 /* MultiThread */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = MultiThread; sourceTree = BUILT_PRODUCTS_DIR; };
+		3020B53A1F26E681000A2332 /* main.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = main.cpp; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		3020B5341F26E681000A2332 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		3020B52E1F26E681000A2332 = {
+			isa = PBXGroup;
+			children = (
+				3020B5391F26E681000A2332 /* MultiThread */,
+				3020B5381F26E681000A2332 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		3020B5381F26E681000A2332 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				3020B5371F26E681000A2332 /* MultiThread */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		3020B5391F26E681000A2332 /* MultiThread */ = {
+			isa = PBXGroup;
+			children = (
+				3020B53A1F26E681000A2332 /* main.cpp */,
+			);
+			path = MultiThread;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		3020B5361F26E681000A2332 /* MultiThread */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3020B53E1F26E681000A2332 /* Build configuration list for PBXNativeTarget "MultiThread" */;
+			buildPhases = (
+				3020B5331F26E681000A2332 /* Sources */,
+				3020B5341F26E681000A2332 /* Frameworks */,
+				3020B5351F26E681000A2332 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MultiThread;
+			productName = MultiThread;
+			productReference = 3020B5371F26E681000A2332 /* MultiThread */;
+			productType = "com.apple.product-type.tool";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		3020B52F1F26E681000A2332 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0830;
+				ORGANIZATIONNAME = tomotaka.yamasaki;
+				TargetAttributes = {
+					3020B5361F26E681000A2332 = {
+						CreatedOnToolsVersion = 8.3.2;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = 3020B5321F26E681000A2332 /* Build configuration list for PBXProject "MultiThread" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 3020B52E1F26E681000A2332;
+			productRefGroup = 3020B5381F26E681000A2332 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				3020B5361F26E681000A2332 /* MultiThread */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		3020B5331F26E681000A2332 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3020B53B1F26E681000A2332 /* main.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		3020B53C1F26E681000A2332 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		3020B53D1F26E681000A2332 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		3020B53F1F26E681000A2332 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		3020B5401F26E681000A2332 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		3020B5321F26E681000A2332 /* Build configuration list for PBXProject "MultiThread" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3020B53C1F26E681000A2332 /* Debug */,
+				3020B53D1F26E681000A2332 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3020B53E1F26E681000A2332 /* Build configuration list for PBXNativeTarget "MultiThread" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3020B53F1F26E681000A2332 /* Debug */,
+				3020B5401F26E681000A2332 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 3020B52F1F26E681000A2332 /* Project object */;
+}

--- a/MultiThread/MultiThread.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/MultiThread/MultiThread.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:MultiThread.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/MultiThread/MultiThread/main.cpp
+++ b/MultiThread/MultiThread/main.cpp
@@ -1,0 +1,15 @@
+//
+//  main.cpp
+//  MultiThread
+//
+//  Created by tomotaka.yamasaki on 2017/07/25.
+//  Copyright © 2017年 tomotaka.yamasaki. All rights reserved.
+//
+
+#include <iostream>
+
+int main(int argc, const char * argv[]) {
+    // insert code here...
+    std::cout << "Hello, World!\n";
+    return 0;
+}

--- a/MultiThread/MultiThread/main.cpp
+++ b/MultiThread/MultiThread/main.cpp
@@ -1,15 +1,109 @@
-//
-//  main.cpp
-//  MultiThread
-//
-//  Created by tomotaka.yamasaki on 2017/07/25.
-//  Copyright © 2017年 tomotaka.yamasaki. All rights reserved.
-//
-
 #include <iostream>
+#include <vector>
+#include <numeric>
+#include <pthread.h>
 
-int main(int argc, const char * argv[]) {
-    // insert code here...
-    std::cout << "Hello, World!\n";
+#include <unistd.h>
+
+namespace {
+    const uint32_t N = 256;    // リングバッファ限界値
+}  // namespace
+
+pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
+
+template <typename T>
+class MultiThreadQueue
+{
+public:
+    void enqueue(const T &data)
+    {
+#ifdef _LOCK
+        pthread_mutex_lock(&m);
+#endif
+        int next = (_tail + 1) % N;
+        if (next != _head) {    // リングバッファがいっぱいではない
+            _data[_tail] = data;
+            _tail = next;
+        }
+#ifdef _LOCK
+        pthread_mutex_unlock(&m);
+#endif
+    }
+
+    T dequeue()
+    {
+#ifdef _LOCK
+        pthread_mutex_lock(&m);
+#endif
+        T ret = T();
+        if (_head != _tail) {    // リングバッファが空ではない
+            ret = _data[_head];
+            _head = (_head + 1) % N;
+        }
+#ifdef _LOCK
+        pthread_mutex_unlock(&m);
+#endif
+        return ret;
+    }
+
+private:
+    T _data[N];       // バッファ
+    int _head = 0;    // 読み出しポインタ
+    int _tail = 0;    // 書き出しポインタ
+};
+
+struct WorkData
+{
+    enum {
+        MESSAGE_TERMINATE,
+        MESSAGE_CALCSUM,
+    } message;
+    std::vector<int> vec;
+};
+
+MultiThreadQueue<WorkData> queue;
+
+void* worker(void *)
+{
+    /* 渡されたWorkDataに基づいて処理する */
+    for (;;) {
+        WorkData data = queue.dequeue();
+
+        if (data.message == WorkData::MESSAGE_TERMINATE) {
+            /* スレッドを終了する */
+            pthread_exit(NULL);
+            break;
+        }
+
+        if (data.message == WorkData::MESSAGE_CALCSUM) {
+            int sum = std::accumulate(data.vec.begin(), data.vec.end(), 0);
+
+            printf("sum of vector is %d\n", sum);
+        }
+    }
+
+    return nullptr;
+}
+
+int main()
+{
+    /* スレッドを起動する */
+    pthread_t th1;
+    pthread_create(&th1, NULL, worker, NULL);
+
+    WorkData work1 = { WorkData::MESSAGE_CALCSUM, { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 } };        // 55
+    queue.enqueue(work1);
+    WorkData work2 = { WorkData::MESSAGE_CALCSUM, { 1, 3, 5, 7, 9, 11, 13, 15, 17, 19 } };    // 100
+    queue.enqueue(work2);
+    WorkData work3 = { WorkData::MESSAGE_CALCSUM, { 1, -1, 3, -3, 5, -5, 7, -7, 9, -9 } };    // 0
+    queue.enqueue(work3);
+    WorkData work4 = { WorkData::MESSAGE_CALCSUM, { 1, 4, 9, 16, 25, 36, 49, 64, 81, 100 } }; // 385
+    queue.enqueue(work4);
+    WorkData work5 = { WorkData::MESSAGE_TERMINATE, { } };
+    queue.enqueue(work5);
+
+    /* スレッドの終了を待つ */
+    pthread_join(th1, NULL);
+
     return 0;
 }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # what-is-programming
 勉強用レポジトリ
+
+# ディレクトリ
+## MultiThread
+- Mutexを使ってキュー構造を実装する


### PR DESCRIPTION
## 目的
- マルチスレッドプログラミングを理解する

## 概要
- Semaphoreを使ってキュー構造を実装する
  - 結局MacではSemaphore使えなかったのでMutexにした

## 詳細
- MultiThreadQueueクラス
  - enqueue、dequeueはクリティカルセクションなのでロック
  - キューに何もたまっていないときはdequeueはセマフォ0で待ち状態になる
  - N上限のリングバッファである
- main.cpp
  - workerメソッドを別のスレッド(th1)で実行させておく
  - メインスレッドでWorkDataをキューに積み(enqueue)、スレッドth1ではキューから取り出してworkを実行させている
  - enqueue、dequeueを別スレッドで行っているため、ロックしていないと読み出し(書き込み)位置を記録している_head、_tailが対応しなくなり、キューに溜まっているのにも関わらず取り出せなかったりする

```
- enqueue
  1. キューに積む
  2. 書き込み位置(_tail)を+1する
- dequeue
  1. キューから取り出す
  2. 読み出し位置(_head)を+1する

- enqueueの1で止まっている最中、dequeueが2回連続で呼ばれた場合、キューに最後に積まれた値が取り出せない
- dequeueの1で止まっている最中、enqueueが2回連続で呼ばれた場合、キューに空きがあるのに積めない
```

## 実行方法
1. MultiThread/MultiThread.xcodeproj を開く
2. XcodeでRun

## セマフォで実現する方法
e017037 のコミットから更に、もう1つセマフォを追加する。
```
sem1 = 0;  // 空かどうか
sem2 = N;  // いっぱいかどうか

enqueue() {
    sem_wait(sem2);
    // キューに入れる
    sem_post(sem1);
}

dequeue() {
    sem_wait(sem1);
    // キューから出す
    sem_post(sem2);
}
```

##### キーワード
- キュー構造
- リングバッファ
- POSIX Threadライブラリ
- Semaphore
- Producer-Consumerパターン
- 状態変数