### PR TITLE
Reader-Writerパターンを実装する

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@
 # ディレクトリ
 ## MultiThread
 - Mutexを使ってキュー構造を実装する
+
+## ReaderWriterProblem
+- マルチスレッドのReader-Writer問題を実装する
+

--- a/ReaderWriterProblem/ReaderWriterProblem.xcodeproj/project.pbxproj
+++ b/ReaderWriterProblem/ReaderWriterProblem.xcodeproj/project.pbxproj
@@ -1,0 +1,255 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		30058C1D1F482FA4007D9F7E /* main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 30058C1C1F482FA4007D9F7E /* main.cpp */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		30058C171F482FA4007D9F7E /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		30058C191F482FA4007D9F7E /* ReaderWriterProblem */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = ReaderWriterProblem; sourceTree = BUILT_PRODUCTS_DIR; };
+		30058C1C1F482FA4007D9F7E /* main.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = main.cpp; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		30058C161F482FA4007D9F7E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		30058C101F482FA4007D9F7E = {
+			isa = PBXGroup;
+			children = (
+				30058C1B1F482FA4007D9F7E /* ReaderWriterProblem */,
+				30058C1A1F482FA4007D9F7E /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		30058C1A1F482FA4007D9F7E /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				30058C191F482FA4007D9F7E /* ReaderWriterProblem */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		30058C1B1F482FA4007D9F7E /* ReaderWriterProblem */ = {
+			isa = PBXGroup;
+			children = (
+				30058C1C1F482FA4007D9F7E /* main.cpp */,
+			);
+			path = ReaderWriterProblem;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		30058C181F482FA4007D9F7E /* ReaderWriterProblem */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 30058C201F482FA4007D9F7E /* Build configuration list for PBXNativeTarget "ReaderWriterProblem" */;
+			buildPhases = (
+				30058C151F482FA4007D9F7E /* Sources */,
+				30058C161F482FA4007D9F7E /* Frameworks */,
+				30058C171F482FA4007D9F7E /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ReaderWriterProblem;
+			productName = ReaderWriterProblem;
+			productReference = 30058C191F482FA4007D9F7E /* ReaderWriterProblem */;
+			productType = "com.apple.product-type.tool";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		30058C111F482FA4007D9F7E /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0830;
+				ORGANIZATIONNAME = tomotaka.yamasaki;
+				TargetAttributes = {
+					30058C181F482FA4007D9F7E = {
+						CreatedOnToolsVersion = 8.3.2;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = 30058C141F482FA4007D9F7E /* Build configuration list for PBXProject "ReaderWriterProblem" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 30058C101F482FA4007D9F7E;
+			productRefGroup = 30058C1A1F482FA4007D9F7E /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				30058C181F482FA4007D9F7E /* ReaderWriterProblem */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		30058C151F482FA4007D9F7E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				30058C1D1F482FA4007D9F7E /* main.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		30058C1E1F482FA4007D9F7E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		30058C1F1F482FA4007D9F7E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		30058C211F482FA4007D9F7E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		30058C221F482FA4007D9F7E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		30058C141F482FA4007D9F7E /* Build configuration list for PBXProject "ReaderWriterProblem" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				30058C1E1F482FA4007D9F7E /* Debug */,
+				30058C1F1F482FA4007D9F7E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		30058C201F482FA4007D9F7E /* Build configuration list for PBXNativeTarget "ReaderWriterProblem" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				30058C211F482FA4007D9F7E /* Debug */,
+				30058C221F482FA4007D9F7E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 30058C111F482FA4007D9F7E /* Project object */;
+}

--- a/ReaderWriterProblem/ReaderWriterProblem.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ReaderWriterProblem/ReaderWriterProblem.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:ReaderWriterProblem.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/ReaderWriterProblem/ReaderWriterProblem/main.cpp
+++ b/ReaderWriterProblem/ReaderWriterProblem/main.cpp
@@ -1,0 +1,7 @@
+#include <iostream>
+
+int main(int argc, const char * argv[]) {
+    // insert code here...
+    std::cout << "Hello, World!\n";
+    return 0;
+}

--- a/ReaderWriterProblem/ReaderWriterProblem/main.cpp
+++ b/ReaderWriterProblem/ReaderWriterProblem/main.cpp
@@ -13,125 +13,154 @@
 
 #include <unistd.h>
 
+namespace {
+    const int WORD_SIZE = 10;
+    const int RANDOM_WORD_SIZE = 20;
+    const int W_TH_NUM = 3;
+    const int R_TH_NUM = 10;
+}  // namespace
+
 class RWLock
 {
 public:
-    void writeOpen()
+    RWLock()
+    : _readingReaders(0)
+    , _writingWriters(0)
+    , _waitingWriters(0)
     {
-        printf("Write open.\n");
-        _writerNum++;
     }
 
     void readOpen()
     {
-        printf("Read open.\n");
-        _readerNum++;
-    }
+        std::unique_lock<std::mutex> rlock(_mtx);
 
-    void writeClose()
-    {
-        printf("Write close.\n");
-        _writerNum--;
+        // Writerが0 かつ　待ちWriterが0 になるまで待つ
+        _not_writing.wait(rlock, [this] { return _writingWriters <= 0 && _waitingWriters <= 0; });
+
+        _readingReaders++;
+        printf("Read open. Reader:%d\n", _readingReaders);
     }
 
     void readClose()
     {
-        printf("Read close.\n");
-        _readerNum--;
+        std::lock_guard<std::mutex> rlock(_mtx);
+        _readingReaders--;
+        // 待ちスレッドに知らせる
+        _not_writing.notify_all();
+        printf("Read close. Reader:%d\n", _readingReaders);
     }
 
-    void write(const char* word)
+    void writeOpen()
     {
-        // ファイルに書き込む とりあえず文字連結
-        strcat(_file, word);
+        std::unique_lock<std::mutex> wlock(_mtx);
+
+        _waitingWriters++;
+
+        // Readerが0 かつ Writerが0 になるまで待つ
+        _not_writing.wait(wlock, [this]{ return _readingReaders <= 0 && _writingWriters <= 0; });
+
+        _waitingWriters--;
+
+        _writingWriters++;
+        printf("Write open. WaitingWriter:%d\n", _waitingWriters);
     }
 
-    char* read()
+    void writeClose()
     {
-        return _file;
+        std::lock_guard<std::mutex> wlock(_mtx);
+        _writingWriters--;
+        // 待ちスレッドに知らせる
+        _not_writing.notify_all();
+        printf("Write close.\n");
     }
-
-    std::unique_lock<std::mutex> getWLock()
-    {
-        return std::unique_lock<std::mutex>(_wmtx);
-    }
-
-    int getWriterNum() { return _writerNum; }
-    int getReaderNum() { return _readerNum; }
 
 private:
-    // ファイル とりあえず変数にしとく
-    char _file[256];
-
-    int _writerNum = 0;
-    int _readerNum = 0;
-    std::mutex _wmtx;
+    int _readingReaders;
+    int _writingWriters;
+    int _waitingWriters;
+    std::mutex _mtx;
+    std::condition_variable _not_writing;
 };
-
-RWLock rwLock;
-std::condition_variable reading;
-std::condition_variable writing;
 
 void randomSleep()
 {
-    int time = rand() % 3;
+    int time = rand() % 2;
     sleep(time);
 }
 
-// 一定タイミングでファイルを書きに行く人
-void* writer(void *)
+class Data
 {
-    std::unique_lock<std::mutex> wlock = rwLock.getWLock();
-    if (rwLock.getReaderNum() > 0) {
-        reading.wait(wlock, [] { return rwLock.getReaderNum() <= 0; });
-    }
-    rwLock.writeOpen();
-    randomSleep();
-    rwLock.write("x ");
-    rwLock.writeClose();
+public:
+    char* read(char* word)
+    {
+        _rwLock.readOpen();
+        strncpy(word, _buffer, WORD_SIZE);
+        word[WORD_SIZE] = '\n';
+        randomSleep();
+        _rwLock.readClose();
 
-    writing.notify_all();
+        return word;
+    }
+
+    void write(char* word)
+    {
+        _rwLock.writeOpen();
+
+        int offs = (rand() % RANDOM_WORD_SIZE);
+        char* buf2 = word + sizeof(char) * offs;
+        char c = buf2[0];
+        for (int i = 0; i < WORD_SIZE - 1; i++) {
+            _buffer[i] = c;
+            randomSleep();
+        }
+        _rwLock.writeClose();
+    }
+
+private:
+    char _buffer[WORD_SIZE];
+    RWLock _rwLock;
+};
+
+// 一定タイミングでファイルを書きに行く人
+void* writer(void* p)
+{
+    randomSleep();
+
+    Data* data = (Data*)p;
+    char word[] = "ABCDEFGHIJKLMN*+-#,.";
+    data->write(word);
 
     pthread_exit(NULL);
-    return nullptr;
 }
 
 // 一定タイミングでファイルを読みに行く人
-void* reader(void *)
+void* reader(void* p)
 {
-    if (rwLock.getWriterNum() > 0) {
-        std::mutex rmtx;
-        std::unique_lock<std::mutex> rlock(rmtx);
-        writing.wait(rlock);
-    }
-
-    rwLock.readOpen();
     randomSleep();
-    char* word = rwLock.read();
-    printf("R:%s\n", word);
-    rwLock.readClose();
 
-    reading.notify_one();
+    Data* data = (Data*)p;
+    char word[WORD_SIZE];
+    char* ret;
+    ret = data->read(word);
+    printf("read: %s\n", ret);
 
     pthread_exit(NULL);
-    return nullptr;
 }
 
 int main()
 {
-    const int W_TH_NUM = 3;
-    const int R_TH_NUM = 3;
+    Data* data = new Data();
 
     /* スレッドを起動する */
     pthread_t writeThreads[W_TH_NUM];
     for (int i = 0; i < W_TH_NUM; i++) {
-        pthread_create(&writeThreads[i], NULL, writer, NULL);
+        pthread_create(&writeThreads[i], NULL, writer, (void*)data);
     }
 
     /* スレッドを起動する */
     pthread_t readThreads[R_TH_NUM];
     for (int i = 0; i < R_TH_NUM; i++) {
-        pthread_create(&readThreads[i], NULL, reader, NULL);
+        pthread_create(&readThreads[i], NULL, reader, (void*)data);
     }
 
     /* スレッドの終了を待つ */

--- a/ReaderWriterProblem/ReaderWriterProblem/main.cpp
+++ b/ReaderWriterProblem/ReaderWriterProblem/main.cpp
@@ -2,7 +2,7 @@
  * Reader-Writer問題をセマフォ(状態変数)を使って解決せよ
  * 以下の特徴をキープすること
  *    1. Readerは複数同時にいても問題ない
- *    2. Readerがいる場合、Writerは書けない(WriteしているときはReaderができない)
+ *    2. Readerがいる場合、Writerは書けない(WriteしているときはReadができない)
  *    3. Writerは複数同時にいてはいけない
  */
 

--- a/ReaderWriterProblem/ReaderWriterProblem/main.cpp
+++ b/ReaderWriterProblem/ReaderWriterProblem/main.cpp
@@ -73,7 +73,7 @@ public:
         _writingWriters--;
         _preferReader = true;  // 読み手を優先させる
         // 待ちスレッドに知らせる
-        _not_writing.notify_all();
+        _not_writing.notify_one();
         printf("Write close.\n");
     }
 

--- a/ReaderWriterProblem/ReaderWriterProblem/main.cpp
+++ b/ReaderWriterProblem/ReaderWriterProblem/main.cpp
@@ -1,7 +1,146 @@
-#include <iostream>
+/**
+ * Reader-Writer問題をセマフォ(状態変数)を使って解決せよ
+ * 以下の特徴をキープすること
+ *    1. Readerは複数同時にいても問題ない
+ *    2. Readerがいる場合、Writerは書けない(WriteしているときはReaderができない)
+ *    3. Writerは複数同時にいてはいけない
+ */
 
-int main(int argc, const char * argv[]) {
-    // insert code here...
-    std::cout << "Hello, World!\n";
+#include <iostream>
+#include <vector>
+#include <pthread.h>
+#include <condition_variable>
+
+#include <unistd.h>
+
+class RWLock
+{
+public:
+    void writeOpen()
+    {
+        printf("Write open.\n");
+        _writerNum++;
+    }
+
+    void readOpen()
+    {
+        printf("Read open.\n");
+        _readerNum++;
+    }
+
+    void writeClose()
+    {
+        printf("Write close.\n");
+        _writerNum--;
+    }
+
+    void readClose()
+    {
+        printf("Read close.\n");
+        _readerNum--;
+    }
+
+    void write(const char* word)
+    {
+        // ファイルに書き込む とりあえず文字連結
+        strcat(_file, word);
+    }
+
+    char* read()
+    {
+        return _file;
+    }
+
+    std::unique_lock<std::mutex> getWLock()
+    {
+        return std::unique_lock<std::mutex>(_wmtx);
+    }
+
+    int getWriterNum() { return _writerNum; }
+    int getReaderNum() { return _readerNum; }
+
+private:
+    // ファイル とりあえず変数にしとく
+    char _file[256];
+
+    int _writerNum = 0;
+    int _readerNum = 0;
+    std::mutex _wmtx;
+};
+
+RWLock rwLock;
+std::condition_variable reading;
+std::condition_variable writing;
+
+void randomSleep()
+{
+    int time = rand() % 3;
+    sleep(time);
+}
+
+// 一定タイミングでファイルを書きに行く人
+void* writer(void *)
+{
+    std::unique_lock<std::mutex> wlock = rwLock.getWLock();
+    if (rwLock.getReaderNum() > 0) {
+        reading.wait(wlock, [] { return rwLock.getReaderNum() <= 0; });
+    }
+    rwLock.writeOpen();
+    randomSleep();
+    rwLock.write("x ");
+    rwLock.writeClose();
+
+    writing.notify_all();
+
+    pthread_exit(NULL);
+    return nullptr;
+}
+
+// 一定タイミングでファイルを読みに行く人
+void* reader(void *)
+{
+    if (rwLock.getWriterNum() > 0) {
+        std::mutex rmtx;
+        std::unique_lock<std::mutex> rlock(rmtx);
+        writing.wait(rlock);
+    }
+
+    rwLock.readOpen();
+    randomSleep();
+    char* word = rwLock.read();
+    printf("R:%s\n", word);
+    rwLock.readClose();
+
+    reading.notify_one();
+
+    pthread_exit(NULL);
+    return nullptr;
+}
+
+int main()
+{
+    const int W_TH_NUM = 3;
+    const int R_TH_NUM = 3;
+
+    /* スレッドを起動する */
+    pthread_t writeThreads[W_TH_NUM];
+    for (int i = 0; i < W_TH_NUM; i++) {
+        pthread_create(&writeThreads[i], NULL, writer, NULL);
+    }
+
+    /* スレッドを起動する */
+    pthread_t readThreads[R_TH_NUM];
+    for (int i = 0; i < R_TH_NUM; i++) {
+        pthread_create(&readThreads[i], NULL, reader, NULL);
+    }
+
+    /* スレッドの終了を待つ */
+    for (auto writeThread : writeThreads) {
+        pthread_join(writeThread, NULL);
+    }
+    for (auto readThread : readThreads) {
+        pthread_join(readThread, NULL);
+    }
+
     return 0;
 }


### PR DESCRIPTION
## 概要
- Reader-Writerパターンを実装する

## Reader-Writerパターン
 1. Readerは複数同時にいても問題ない
 2. Readerがいる場合、Writerは書けない(WriteしているときはReaderができない)
 3. Writerは複数同時にいてはいけない

## 詳細
### 各クラス、メソッドの役割
#### サマリー
- RWLockクラス: 
  - Mutexを使って実際にロックをかけるクラス
- Dataクラス: 
  - Reader,Writerが触るデータ
  - インスタンスは1つしかない
  - データを操作するインターフェースを備えている
  - RWLockを操作するクラス
- Reader, Writer: 
  - ReadとWriteをするだけ
  - ロックがかかっているかどうかは意識させない

#### RWLockクラス
- DataのReadLock、WriteLockを管理するクラス
- Dataクラスで使用する
- 以下の情報を元にLockをかけるかどうか判断する
  - 読んでいる人数
  - 書いている人数
  - 書き待ちの人数
- Readは｢Writerが0 かつ 待ちWriterが0 になるまで待つ｣
- Writeは｢Readerが0 かつ Writerが0 になるまで待つ｣

#### Dataクラス
- データを管理するクラス
- ReadとWriteのインターフェースを備える
- Read、Writeを行う際にRWLockクラスにLock状態を問い合わせる

#### writer
- 一定タイミングでファイルを書きに行く人
- 1writer1スレッド

#### reader
- 一定タイミングでファイルを読みに行く人
- 1reader1スレッド

## なぜ条件変数にmutexを渡すのか？
https://docs.google.com/presentation/d/1EonyZXSzv4uvAPrKTMeN9DwXDcwWZexY7ZVsfb14ECw/edit#slide=id.p
一言で言うと、共有の条件変数を使う各スレッドで同期を取るため。
同期を取らないと、条件チェック→条件待ちに入る間に通知が来て、待ちから抜け出せなくなってしまう。

Reader-Writerパターンは実行中のスレッドの数(実行条件)が重要なので、
同期をとる必要がある。

## なぜReaderのガード条件にWriterの数以外の変数があるのか？
- Writerは他のWriterがいるときやReaderがいるときは書けない
- Readerは他のReaderがいるときは読めるが、Writerがいるときは読めない

これだけなら、waitのガード条件で

- ReadOpen: 書き手が0になるまで待つ
- WriteOpen: 書き手と読み手が0になるまで待つ

とすれば良い。
しかし、この条件のまま実行すると、良くない事が起きる。
Readerスレッドが10個、Writerスレッドが3個あったとする(Reader > Writer)。

Read実行中はWriterは待たされるが、Readerは待たないのでどんどん実行される。
いつまでたってもWriteが実行されない。結果として、Read実行が全て終わった後にWriteが行われてしまう。

Write待ちの人がいればReadを実行できないようにする(waitingWriters <= 0)だけだと、
今度はReaderが待ち続けることになってしまう。

なので、ReadかWriteどちらを優先させるか決めるフラグが必要(preferReader)。
preferReaderはWrite実行が終わった後にtrueになり、Read実行が終わった後にfalseになる。
Read優先であれば、Write待ち人数が1人以上でも読み手が優先される。

これにより、ReaderスレッドWriterスレッドが交互に実行されるようになる。

## ToDo(できていないこと)
- [x] Reader-Writerパターンのルールを守れていない
  - Writerが書いている途中にReaderが読みに行っている
- [x] スレッドの終了がうまく行っていない